### PR TITLE
Permutations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 use std::iter::Iterator;
 use std::mem::MaybeUninit;
 
-pub trait IterExt: Iterator + Clone + Sized
+pub trait IterExt: Iterator + Sized
 where
     <Self as Iterator>::Item: Clone,
 {
@@ -29,14 +29,14 @@ where
 
 impl<I> IterExt for I
 where
-    I: Clone + Iterator,
+    I: Iterator,
     <I as Iterator>::Item: Clone,
 {
 }
 
 pub struct Combinations<I, const N: usize>
 where
-    I: Clone + Iterator,
+    I: Iterator,
     I::Item: Clone,
 {
     iter: I,
@@ -48,7 +48,7 @@ where
 
 impl<I, const N: usize> Combinations<I, N>
 where
-    I: Clone + Iterator,
+    I: Iterator,
     I::Item: Clone,
 {
     fn new(mut iter: I) -> Self {
@@ -74,7 +74,7 @@ where
 
 impl<I, const N: usize> Iterator for Combinations<I, N>
 where
-    I: Clone + Iterator,
+    I: Iterator,
     I::Item: Clone,
 {
     type Item = [I::Item; N];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ mod test {
     }
 
     #[test]
-     fn combinations_none_on_size_too_big() {
+    fn combinations_none_on_size_too_big() {
         let mut combinations = (1..2).combinations::<2>();
         assert_eq!(combinations.next(), None);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use std::mem::MaybeUninit;
 
 pub trait IterExt: Iterator + Sized
 where
-    <Self as Iterator>::Item: Clone,
+    Self::Item: Clone,
 {
     fn combinations<const N: usize>(self) -> Combinations<Self, N> {
         Combinations::new(self)
@@ -30,7 +30,7 @@ where
 impl<I> IterExt for I
 where
     I: Iterator,
-    <I as Iterator>::Item: Clone,
+    I::Item: Clone,
 {
 }
 
@@ -79,7 +79,7 @@ where
 {
     type Item = [I::Item; N];
 
-    fn next(&mut self) -> Option<[<I as Iterator>::Item; N]> {
+    fn next(&mut self) -> Option<[I::Item; N]> {
         if self.first {
             // Validate N never exceeds the total no. of items in the iterator
             if N > self.buffer.len() {


### PR DESCRIPTION
This is the first stab at permutations. Outputting k-permutations lexicographically is a quite a pain, so instead I compose it with `Combinations` and return all permutations of each k-combination.

- Is composition desirable? I haven't seen an interator in `std` which does that, though I haven't been looking that thoroughly.
- Is it ok that the order is not lexicographic?
- Is it ok that there is an extra clone per k-combination observable by the user?