### PR TITLE
Combinations fixes

### DIFF
--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -62,6 +62,8 @@ where
             }
             self.first = false;
         } else if K == 0 {
+            // This check is separated, because in case of K == 0 we still
+            // need to return a single empty array before returning None.
             return None;
         } else {
             // Check if we need to consume more from the iterator

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -110,11 +110,13 @@ mod test {
         assert_eq!(combinations.next(), Some([2, 4, 5]));
         assert_eq!(combinations.next(), Some([3, 4, 5]));
         assert_eq!(combinations.next(), None);
+        assert_eq!(combinations.next(), None);
     }
 
     #[test]
     fn none_on_size_too_big() {
         let mut combinations = (1..2).combinations::<2>();
+        assert_eq!(combinations.next(), None);
         assert_eq!(combinations.next(), None);
     }
 
@@ -122,6 +124,7 @@ mod test {
     fn empty_arr_on_n_zero() {
         let mut combinations = (1..5).combinations();
         assert_eq!(combinations.next(), Some([]));
+        assert_eq!(combinations.next(), None);
         assert_eq!(combinations.next(), None);
     }
 }

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -127,4 +127,28 @@ mod test {
         assert_eq!(combinations.next(), None);
         assert_eq!(combinations.next(), None);
     }
+
+    #[test]
+    fn resume_after_none() {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let mut combinations = receiver.try_iter().combinations();
+        assert_eq!(combinations.next(), None);
+
+        sender.send(1).unwrap();
+        assert_eq!(combinations.next(), None);
+
+        sender.send(2).unwrap();
+        assert_eq!(combinations.next(), None);
+
+        sender.send(3).unwrap();
+        assert_eq!(combinations.next(), Some([1, 2, 3]));
+        assert_eq!(combinations.next(), None);
+
+        sender.send(4).unwrap();
+        assert_eq!(combinations.next(), Some([1, 2, 4]));
+        assert_eq!(combinations.next(), Some([1, 3, 4]));
+        assert_eq!(combinations.next(), Some([2, 3, 4]));
+        assert_eq!(combinations.next(), None);
+        assert_eq!(combinations.next(), None);
+    }
 }

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -85,7 +85,7 @@ where
             self.indices[i] += 1;
         }
 
-        // Create result vector based on the indexes
+        // Create the result array based on the indices
         let mut out: [MaybeUninit<I::Item>; K] = MaybeUninit::uninit_array();
         self.indices.iter().enumerate().for_each(|(oi, i)| {
             out[oi] = MaybeUninit::new(self.buffer[*i].clone());

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -36,7 +36,7 @@ where
         }
 
         Self {
-            buffer: Vec::with_capacity(K),
+            buffer: Vec::new(),
             indices,
             first: true,
             iter,
@@ -54,6 +54,7 @@ where
     fn next(&mut self) -> Option<[I::Item; K]> {
         if self.first {
             // Fill the buffer for the first combination
+            self.buffer.reserve(K - self.buffer.len());
             while self.buffer.len() < K {
                 match self.iter.next() {
                     Some(x) => self.buffer.push(x),

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -26,7 +26,7 @@ where
     I: Iterator,
     I::Item: Clone,
 {
-    pub(crate) fn new(mut iter: I) -> Self {
+    pub(crate) fn new(iter: I) -> Self {
         // Prepare the indices.
         let mut indices = [0; K];
         // NOTE: this clippy attribute can be removed once we can `collect` into `[usize; K]`.
@@ -36,7 +36,7 @@ where
         }
 
         Self {
-            buffer: iter.by_ref().take(K).collect(),
+            buffer: Vec::with_capacity(K),
             indices,
             first: true,
             iter,
@@ -53,9 +53,12 @@ where
 
     fn next(&mut self) -> Option<[I::Item; K]> {
         if self.first {
-            // Validate K never exceeds the total no. of items in the iterator
-            if K > self.buffer.len() {
-                return None;
+            // Fill the buffer for the first combination
+            while self.buffer.len() < K {
+                match self.iter.next() {
+                    Some(x) => self.buffer.push(x),
+                    None => return None,
+                }
             }
             self.first = false;
         } else if K == 0 {

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -74,15 +74,13 @@ where
             }
 
             let mut i = 0;
-            // Find the last consecutive index
+            // Reset consecutive indices
             while i < K - 1 && self.indices[i] + 1 == self.indices[i + 1] {
+                self.indices[i] = i;
                 i += 1;
             }
+            // Increment the last consecutive index
             self.indices[i] += 1;
-            // Increment index, and reset the ones to its left
-            for j in 0..i {
-                self.indices[j] = j;
-            }
         }
 
         // Create result vector based on the indexes

--- a/src/permutations.rs
+++ b/src/permutations.rs
@@ -117,4 +117,27 @@ mod test {
         assert_eq!(permutations.next(), Some([]));
         assert_eq!(permutations.next(), None);
     }
+
+    #[test]
+    fn resume_after_none() {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let mut permutations = receiver.try_iter().permutations();
+        assert_eq!(permutations.next(), None);
+
+        sender.send(1).unwrap();
+        assert_eq!(permutations.next(), None);
+
+        sender.send(2).unwrap();
+        assert_eq!(permutations.next(), Some([1, 2]));
+        assert_eq!(permutations.next(), Some([2, 1]));
+        assert_eq!(permutations.next(), None);
+
+        sender.send(3).unwrap();
+        assert_eq!(permutations.next(), Some([1, 3]));
+        assert_eq!(permutations.next(), Some([3, 1]));
+        assert_eq!(permutations.next(), Some([2, 3]));
+        assert_eq!(permutations.next(), Some([3, 2]));
+        assert_eq!(permutations.next(), None);
+        assert_eq!(permutations.next(), None);
+    }
 }


### PR DESCRIPTION
- don't pull items from the inner iterator in `new`, do it in `next`
- allow resuming after `None` before there is `K` items
- optimized index reset, the loop is merged with the previous one
- added extra `next` call to the end of tests to check the behavior after finishing
- added tests for resuming after `None`
- small changes in comments