### PR TITLE
Fix compiling on current Rust stable / nightly.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,45 +17,34 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [nightly]
+        rust: [stable]
 
     steps:
     - uses: actions/checkout@master
 
     - name: Install ${{ matrix.rust }}
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        override: true
 
     - name: check
-      uses: actions-rs/cargo@v1
-      with:
-        command: check
-        args: --all --bins --examples
+      run: cargo check --all --bins --examples
 
     - name: check unstable
-      uses: actions-rs/cargo@v1
-      with:
-        command:  check
-        args: --all --benches --bins --examples --tests
+      run: cargo check --all --benches --bins --examples --tests
 
     - name: tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all
+      run: cargo test --all
 
   check_fmt_and_docs:
     name: Checking fmt and docs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: nightly
         components: rustfmt, clippy
-        override: true
 
     - name: fmt
       run: cargo fmt --all -- --check

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -1,4 +1,3 @@
-use crate::make_array;
 use alloc::vec::Vec;
 use core::iter::{FusedIterator, Iterator};
 
@@ -11,7 +10,7 @@ pub struct LazyCombinationGenerator<const K: usize> {
 impl<const K: usize> LazyCombinationGenerator<K> {
     pub fn new() -> Self {
         Self {
-            indices: make_array(|i| i),
+            indices: core::array::from_fn(|i| i),
             done: false,
         }
     }
@@ -69,7 +68,7 @@ impl<const K: usize> State<K> {
             None
         } else {
             let indices = self.gen.indices();
-            let res = make_array(|i| f(&items[indices[i]]));
+            let res = core::array::from_fn(|i| f(&items[indices[i]]));
             self.gen.step();
             Some(res)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@
 //! ```
 
 #![no_std]
-#![feature(maybe_uninit_uninit_array)]
 
 extern crate alloc;
 
@@ -137,7 +136,7 @@ pub trait SliceExt<T> {
     /// assert_eq!(combinations.next(), Some([&2, &2]));
     /// assert_eq!(combinations.next(), None);
     /// ```
-    fn combinations<const K: usize>(&self) -> SliceCombinations<T, K>;
+    fn combinations<const K: usize>(&self) -> SliceCombinations<'_, T, K>;
 
     /// Return an iterator that iterates over the k-length permutations of
     /// the elements from a slice.
@@ -169,31 +168,14 @@ pub trait SliceExt<T> {
     /// assert_eq!(permutations.next(), Some([&2, &2])); // Note: these are the same
     /// assert_eq!(permutations.next(), None);
     /// ```
-    fn permutations<const K: usize>(&self) -> SlicePermutations<T, K>;
+    fn permutations<const K: usize>(&self) -> SlicePermutations<'_, T, K>;
 }
 
 impl<T> SliceExt<T> for [T] {
-    fn combinations<const K: usize>(&self) -> SliceCombinations<T, K> {
+    fn combinations<const K: usize>(&self) -> SliceCombinations<'_, T, K> {
         SliceCombinations::new(self)
     }
-    fn permutations<const K: usize>(&self) -> SlicePermutations<T, K> {
+    fn permutations<const K: usize>(&self) -> SlicePermutations<'_, T, K> {
         SlicePermutations::new(self)
     }
-}
-
-fn make_array<T, F, const N: usize>(f: F) -> [T; N]
-where
-    F: Fn(usize) -> T,
-{
-    use core::mem::MaybeUninit;
-
-    // Create the result array based on the indices
-    let mut out: [MaybeUninit<T>; N] = MaybeUninit::uninit_array();
-
-    // NOTE: this clippy attribute can be removed once we can `collect` into `[usize; K]`.
-    #[allow(clippy::clippy::needless_range_loop)]
-    for i in 0..N {
-        out[i] = MaybeUninit::new(f(i));
-    }
-    unsafe { out.as_ptr().cast::<[T; N]>().read() }
 }

--- a/src/permutations.rs
+++ b/src/permutations.rs
@@ -1,4 +1,4 @@
-use crate::{combinations::LazyCombinationGenerator, make_array};
+use crate::combinations::LazyCombinationGenerator;
 use alloc::vec::Vec;
 use core::iter::{FusedIterator, Iterator};
 
@@ -12,7 +12,7 @@ pub struct LazyPermutationGenerator<const N: usize> {
 impl<const N: usize> LazyPermutationGenerator<N> {
     pub fn new() -> Self {
         Self {
-            indices: make_array(|i| i),
+            indices: core::array::from_fn(|i| i),
             counters: [0; N],
             done: false,
         }
@@ -75,7 +75,7 @@ impl<const K: usize> State<K> {
         } else {
             let comb_indices = self.comb_gen.indices();
             let perm_indices = self.perm_gen.indices();
-            let res = make_array(|i| f(&items[comb_indices[perm_indices[i]]]));
+            let res = core::array::from_fn(|i| f(&items[comb_indices[perm_indices[i]]]));
             self.perm_gen.step();
             if self.perm_gen.is_done() {
                 // Reset the permutation generator and move to the next combination


### PR DESCRIPTION
- `make_array` can now be done with `core::array::from_fn`,
  stable since Rust 1.63. Thus the crate now compiles on stable.

- Resolve some warnings about elided `'_` lifetime in the `Slice*` iterators.

- Fix CI workflow to switch from archived `actions-rs/*` actions to
  `dtolnay/rust-toolchain`.

---

Not sure if you still care about this crate, but I found it while googling for "rust slice combinations" -> couldn't compile it -> realized the fix to make it compile was trivial -> did it -> figured I'd send a PR.